### PR TITLE
Some legit public PDBs have no global data exposed

### DIFF
--- a/crates/bin/main.rs
+++ b/crates/bin/main.rs
@@ -60,7 +60,6 @@ fn main() -> anyhow::Result<()> {
     }
 
     let parsed_pdb = ezpdb::parse_pdb(&opt.file, opt.base_address)?;
-    assert!(!parsed_pdb.global_data.is_empty());
     let stdout = std::io::stdout();
     let mut stdout_lock = stdout.lock();
 


### PR DESCRIPTION
Fixes an assert crash when dumping PDBs that have no global data:
```
>pdbview dbg\sym\ntkrnlmp.pdb\D7ABE9B23BAD553213DE9BB10F1677B81\ntkrnlmp.pdb
thread 'main' panicked at C:\Users\over\.cargo\registry\src\index.crates.io-6f17d22bba15001f\pdbview-0.6.0\crates/bin/main.rs:63:5:
assertion failed: !parsed_pdb.global_data.is_empty()
stack backtrace:

>pdbview dbg\sym\ntdll.pdb\094B224BC5297445CF29F9C9BB588DC91\ntdll.pdb
thread 'main' panicked at C:\Users\over\.cargo\registry\src\index.crates.io-6f17d22bba15001f\pdbview-0.6.0\crates/bin/main.rs:63:5:
assertion failed: !parsed_pdb.global_data.is_empty()
stack backtrace:
```